### PR TITLE
Update URL for Linux-Stammtisch

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -31,7 +31,7 @@
   title: "Linux-Stammtisch"
   location: "Leibnizstr. 32"
   url_title: "Netz39 e.V."
-  url: "http://www.netz39.de/events/event/linux-stammtisch/"
+  url: "http://www.netz39.de/events/event/linux-stammtisch-2/"
 
 - date: "23.01."
   time: "19:00-21:00"


### PR DESCRIPTION
The previous URL was from the event series of last year.

Signed-off-by: Alexander Dahl <alex@netz39.de>