### PR TITLE
fix: Softwerke Stammtisch location

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -22,7 +22,7 @@
   time: "16:00:-20:00"
   org: "Softwerke Magdeburg e.V."
   title: "Softwerke Magdeburg Stammtisch"
-  location: "Tacheles vom platz*machen e. V., Sternstr. 30"
+  location: "Netz39 e.V., Leibnizstraße 32"
   url_title: "softwerke.md"
   url: "https://softwerke.md/"
 


### PR DESCRIPTION
Stammtisch findet im Netz 39 statt im Tacheles statt